### PR TITLE
Detect error messages in htmllint output and fail travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ node_js:
 install:
   - npm install htmllint-cli
 
-script: htmllint **/*.html
+script:
+  - htmllint **/*.html 2>&1 | tee output.log
+  - grep -q '^\[htmllint error' output.log && exit 1 || exit 0


### PR DESCRIPTION
PR for issue #32 
Script must exit with non-zero exit code for travis to fail the build but htmllint does not.
To fix this save stderr output and check for error messages and exit with code 1 if any are found.

@mbernier edit:
closes #32